### PR TITLE
Solved Issue-01: Implement Romanian-style Date Formatting (DD Month YYYY)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ DriveFlow Accountant is a microservice built for driving schools to generate pro
 - Generate PDF invoices with detailed student, instructor, and vehicle information
 - Preview HTML version of the invoice before generation
 - Beautifully styled invoices with responsive layout
+- Romanian date formatting (DD Month YYYY) for better readability
 - Docker support for easy deployment
 - Heroku-ready configuration
 
@@ -56,9 +57,9 @@ Both endpoints accept the same JSON data format:
     "cnp": "1990123456789"  // Optional
   },
   "file": {
-    "scholarshipStartDate": "2023-05-01",  // Format: YYYY-MM-DD
-    "criminalRecordExpiryDate": "2023-12-31",  // Format: YYYY-MM-DD
-    "medicalRecordExpiryDate": "2023-12-31",  // Format: YYYY-MM-DD
+    "scholarshipStartDate": "2023-05-01",  // Format: YYYY-MM-DD (will be displayed as "01 Mai 2023")
+    "criminalRecordExpiryDate": "2023-12-31",  // Format: YYYY-MM-DD (will be displayed as "31 Decembrie 2023")
+    "medicalRecordExpiryDate": "2023-12-31",  // Format: YYYY-MM-DD (will be displayed as "31 Decembrie 2023")
     "status": "Activ"
   },
   "teachingCategory": {
@@ -83,6 +84,19 @@ Both endpoints accept the same JSON data format:
   }
 }
 ```
+
+## Date Formatting
+
+All dates in the generated invoice are automatically formatted in Romanian style:
+- Input format: YYYY-MM-DD (ISO standard)
+- Display format: DD Month YYYY (e.g., "01 Mai 2023")
+- Month names are in Romanian language
+
+This formatting applies to:
+- Issue Date
+- Medical Record Expiry Date
+- Criminal Record Expiry Date
+- Scholarship Start Date
 
 ## Setup and Deployment
 

--- a/app.py
+++ b/app.py
@@ -12,6 +12,27 @@ import random
 import string
 import base64
 
+# Function to format dates in Romanian style
+def format_romanian_date(date_str):
+    """
+    Format a YYYY-MM-DD date to Romanian style (DD Month YYYY)
+    Returns original string if format doesn't match YYYY-MM-DD
+    """
+    ro_months = {
+        1: "Ianuarie", 2: "Februarie", 3: "Martie", 4: "Aprilie",
+        5: "Mai", 6: "Iunie", 7: "Iulie", 8: "August",
+        9: "Septembrie", 10: "Octombrie", 11: "Noiembrie", 12: "Decembrie"
+    }
+    
+    try:
+        # Try to parse the date in YYYY-MM-DD format
+        date_obj = datetime.strptime(date_str, '%Y-%m-%d')
+        # Format as DD Month YYYY in Romanian
+        return f"{date_obj.day:02d} {ro_months[date_obj.month]} {date_obj.year}"
+    except (ValueError, TypeError):
+        # If parsing fails, return the original string
+        return date_str
+
 # Initialize Flask application
 app = Flask(__name__)
 
@@ -141,10 +162,21 @@ def generate_invoice_html(data):
         })
         total += session_total
     
+    # Format dates to Romanian style
+    formatted_issue_date = format_romanian_date(current_date.strftime("%Y-%m-%d"))
+    
+    # Create a copy of file data with formatted dates
+    file_data = {
+        "scholarshipStartDate": format_romanian_date(data.file.scholarshipStartDate),
+        "criminalRecordExpiryDate": format_romanian_date(data.file.criminalRecordExpiryDate),
+        "medicalRecordExpiryDate": format_romanian_date(data.file.medicalRecordExpiryDate),
+        "status": data.file.status
+    }
+    
     # Prepare data for the template
     template_data = {
         'invoice_number': invoice_number,
-        'issue_date': current_date.strftime("%d.%m.%Y"),
+        'issue_date': formatted_issue_date,
         'logo_path': logo_b64,
         'logo_exists': logo_exists,
         'watermark_logo_path': watermark_b64,
@@ -152,7 +184,7 @@ def generate_invoice_html(data):
         'student': data.student,
         'invoice_items': invoice_items,
         'total': f"{total:.2f} RON",
-        'file': data.file,
+        'file': file_data,
         'vehicle': data.vehicle,
         'instructor': data.instructor,
         'teaching_category': data.teachingCategory


### PR DESCRIPTION
# ✨ Implement Romanian-style Date Formatting (DD Month YYYY)

## 📌 Description

This pull request adds support for formatting invoice dates in the Romanian style (e.g., `01 Mai 2023` instead of `2023-05-01`) to improve readability for Romanian users.

---

## 🔧 Changes

### 🗂 Code (in `app.py`)
- Added a `format_romanian_date` function to convert dates from `YYYY-MM-DD` to `DD Month YYYY` using Romanian month names.
- Applied this formatting to the following fields:
  - Invoice issue date
  - Schooling start date
  - Medical certificate expiration date
  - Criminal record expiration date

### 📄 Documentation (`README.md`)
- Added **"Date Formatting"** section explaining the feature and its usage.
- Updated the **Features** list to include this functionality.
- Enhanced JSON examples with comments showing how dates will be displayed after formatting.

---

## ✅ Benefits
- Improved user experience by displaying dates in a format familiar to Romanian users.
- Automatic formatting of all relevant date fields — no manual intervention needed.
- Ensures consistent and readable output across PDF generation and HTML preview endpoints.

---

## 🧪 Testing

- Changes were tested locally and inside Docker.
- Verified correct display on:
  - `/api/v1/getInvoice` (PDF generation)
  - `/preview` (HTML invoice preview)
